### PR TITLE
Require Rust 1.37 or above for ffsend

### DIFF
--- a/net-misc/ffsend/ffsend-0.2.58.ebuild
+++ b/net-misc/ffsend/ffsend-0.2.58.ebuild
@@ -287,7 +287,7 @@ IUSE="libressl"
 DEPEND=""
 RDEPEND=""
 BDEPEND="
-	>=virtual/rust-1.32.0
+	>=virtual/rust-1.37.0
 	libressl? ( dev-libs/libressl )
 	!libressl? ( dev-libs/openssl )
 "


### PR DESCRIPTION
Rust 1.37 or above is required to build the latest `ffsend` from source.

I've edited the `BDEPEND` variable, and am not quite sure if I should update other files as well.